### PR TITLE
Remove deprecated setting android.enableR8=true

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
Android Studio complains about this line during Gradle sync.