### PR TITLE
Feature/ios use delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.5
+
+ * Added method for getting playback position for an audiofile
+ * Added ability to delegate native implementation in iOS
+    * Designed for compatibility with [`twilio_programmable_video`](https://pub.dev/packages/twilio_programmable_video)
+
 ## 0.0.4
 
  * Better handling on iOS when an asset is not found

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
  * Added method for getting playback position for an audiofile
  * Added ability to delegate native implementation in iOS
-    * Designed for compatibility with [`twilio_programmable_video`](https://pub.dev/packages/twilio_programmable_video)
+    * Designed for compatibility with [`twilio_programmable_video`](https://pub.dev/packages/twilio_programmable_video) version `0.6.4`+
 
 ## 0.0.4
 

--- a/android/src/main/kotlin/xyz/erick/ocarina/OcarinaPlugin.kt
+++ b/android/src/main/kotlin/xyz/erick/ocarina/OcarinaPlugin.kt
@@ -94,6 +94,11 @@ abstract class OcarinaPlayer {
     player.seekTo(position);
   }
 
+  fun position(): Long {
+    checkInitialized();
+    return player.getCurrentPosition();
+  }
+
   fun volume(volume: Double) {
     checkInitialized();
     this.volume = volume;
@@ -166,73 +171,115 @@ public class OcarinaPlugin: FlutterPlugin, MethodCallHandler {
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
     if (call.method == "load") {
-      val id = playerIds;
-      val url = call.argument<String>("url");
-      val packageName = call.argument<String>("package");
-      val volume = call.argument<Double>("volume");
-      val loop = call.argument<Boolean>("loop");
-      val isAsset = call.argument<Boolean>("isAsset");
-
-      var player: OcarinaPlayer = if (isAsset!!) {
-        AssetOcarinaPlayer(url!!, packageName, volume!!, loop!!, context, flutterAssets);
-      } else {
-        FileOcarinaPlayer(url!!, volume!!, loop!!, context);
-      }
-      player.load();
-
-      players.put(id, player);
-
-      playerIds++;
-
-      result.success(id);
+      load(call, result)
     } else if (call.method == "play") {
-      val playerId = call.argument<Int>("playerId");
-      val player = players[playerId!!];
-      player!!.play();
-
-      result.success(0);
+      play(call, result)
     } else if (call.method == "stop") {
-      val playerId = call.argument<Int>("playerId");
-      val player = players[playerId!!];
-      player!!.stop();
-
-      result.success(0);
+      stop(call, result)
     } else if (call.method == "pause") {
-      val playerId = call.argument<Int>("playerId");
-      val player = players[playerId!!];
-      player!!.pause();
-
-      result.success(0);
+      pause(call, result)
     } else if (call.method == "resume") {
-      val playerId = call.argument<Int>("playerId");
-      val player = players[playerId!!];
-      player!!.resume();
-
-      result.success(0);
+      resume(call, result)
     } else if (call.method == "seek") {
-      val playerId = call.argument<Int>("playerId");
-      val position = call.argument<Int>("position");
-      val player = players[playerId!!];
-      player!!.seek(position!!.toLong());
-
-      result.success(0);
+      seek(call, result)
+    } else if (call.method == "position") {
+      position(call, result)
     } else if (call.method == "volume") {
-      val playerId = call.argument<Int>("playerId");
-      val volume = call.argument<Double>("volume");
-      val player = players[playerId!!];
-      player!!.volume(volume!!);
-
-      result.success(0);
+      volume(call, result)
     } else if (call.method == "dispose") {
-      val playerId = call.argument<Int>("playerId");
-      val player = players[playerId!!];
-      player!!.dispose();
-      players.remove(playerId!!);
-
-      result.success(0);
+      dispose(call, result)
     } else {
       result.notImplemented()
     }
+  }
+
+  fun load(@NonNull call: MethodCall, @NonNull result: Result) {
+    val id = playerIds;
+    val url = call.argument<String>("url");
+    val packageName = call.argument<String>("package");
+    val volume = call.argument<Double>("volume");
+    val loop = call.argument<Boolean>("loop");
+    val isAsset = call.argument<Boolean>("isAsset");
+
+    var player: OcarinaPlayer = if (isAsset!!) {
+      AssetOcarinaPlayer(url!!, packageName, volume!!, loop!!, context, flutterAssets);
+    } else {
+      FileOcarinaPlayer(url!!, volume!!, loop!!, context);
+    }
+    player.load();
+
+    players.put(id, player);
+
+    playerIds++;
+
+    result.success(id);
+  }
+
+  fun play(@NonNull call: MethodCall, @NonNull result: Result) {
+    val playerId = call.argument<Int>("playerId");
+    val player = players[playerId!!];
+    player!!.play();
+
+    result.success(0);
+  }
+
+  fun stop(@NonNull call: MethodCall, @NonNull result: Result) {
+    val playerId = call.argument<Int>("playerId");
+    val player = players[playerId!!];
+    player!!.stop();
+
+    result.success(0);
+  }
+
+  fun pause(@NonNull call: MethodCall, @NonNull result: Result) {
+    val playerId = call.argument<Int>("playerId");
+    val player = players[playerId!!];
+    player!!.pause();
+
+    result.success(0);
+  }
+
+  fun resume(@NonNull call: MethodCall, @NonNull result: Result) {
+    val playerId = call.argument<Int>("playerId");
+    val player = players[playerId!!];
+    player!!.resume();
+
+    result.success(0);
+  }
+
+  fun seek(@NonNull call: MethodCall, @NonNull result: Result) {
+    val playerId = call.argument<Int>("playerId");
+    val position = call.argument<Int>("position");
+    val player = players[playerId!!];
+    player!!.seek(position!!.toLong());
+
+    result.success(0);
+  }
+
+  fun position(@NonNull call: MethodCall, @NonNull result: Result) {
+    val playerId = call.argument<Int>("playerId");
+    val player = players[playerId!!];
+    val position = player!!.position();
+
+    result.success(position);
+  }
+
+  fun volume(@NonNull call: MethodCall, @NonNull result: Result) {
+    val playerId = call.argument<Int>("playerId");
+    val volume = call.argument<Double>("volume");
+    val player = players[playerId!!];
+    player!!.volume(volume!!);
+
+    result.success(0);
+  }
+
+  fun dispose(@NonNull call: MethodCall, @NonNull result: Result) {
+    val playerId = call.argument<Int>("playerId");
+    val player = players[playerId!!];
+    player!!.dispose();
+    players.remove(playerId!!);
+
+    result.success(0);
   }
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -101,7 +101,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.4"
+    version: "0.0.5"
   path:
     dependency: transitive
     description:

--- a/ios/Classes/SwiftOcarinaPlugin.swift
+++ b/ios/Classes/SwiftOcarinaPlugin.swift
@@ -60,8 +60,7 @@ class LoopPlayer: Player {
         }
         
         let positionInMillis = Int64((Float64(value) / Float64(timescale)) * 1000)
-        
-        NSLog("Ocarina::LoopPlayer => position (ms): \(positionInMillis)")
+
         return positionInMillis
     }
 }
@@ -102,8 +101,7 @@ class SinglePlayer: Player {
     
     func position() -> Int64? {
         let positionInMillis = Int64(player.currentTime * 1000)
-        
-        NSLog("Ocarina::SinglePlayer => position (ms): \(positionInMillis)")
+
         return positionInMillis
     }
 }
@@ -120,18 +118,17 @@ class PlayerDelegate {
     let positionDelegate: PositionDelegate
     
     func load(_ id: Int, assetUrl: String, volume: Double, loop: Bool) {
-        NSLog("Ocarina::PlayerDelegate => loading player \(id) from \(assetUrl) with delegate")
         let url: URL = URL(fileURLWithPath: assetUrl)
         let fileForPlayback: AVAudioFile?
         do {
             fileForPlayback = try AVAudioFile(forReading: url)
         } catch let error {
-            NSLog("Cannot play music. Error opening file \(url) for reading \(error).")
+            NSLog("SwiftOcarinaPlugin::load => Cannot play music. Error opening file \(url) for reading \(error).")
             return
         }
         
         guard let file = fileForPlayback else {
-            NSLog("Cannot play music. Cannot open file for reading \(url).")
+            NSLog("SwiftOcarinaPlugin::load => Cannot play music. Cannot open file for reading \(url).")
             return
         }
 
@@ -143,32 +140,26 @@ class PlayerDelegate {
     }
     
     func play(_ id: Int) {
-        NSLog("Ocarina::PlayerDelegate => playing \(id) with delegate")
         playDelegate(id)
     }
 
     func pause(_ id: Int) {
-        NSLog("Ocarina::PlayerDelegate => pausing \(id) with delegate")
         pauseDelegate(id)
     }
 
     func resume(_ id: Int) {
-        NSLog("Ocarina::PlayerDelegate => resuming \(id) with delegate")
         resumeDelegate(id)
     }
 
     func stop(_ id: Int) {
-        NSLog("Ocarina::PlayerDelegate => stopping \(id) with delegate")
         stopDelegate(id)
     }
 
     func volume(_ id: Int, volume: Double) {
-        NSLog("Ocarina::PlayerDelegate => setting volume for player \(id) to \(volume) with delegate")
         volumeDelegate(id, volume)
     }
     
     func seek(_ id: Int, positionInMillis: Int) {
-        NSLog("Ocarina::PlayerDelegate => seeking for player \(id) to position \(positionInMillis) ms")
         seekDelegate(id, positionInMillis)
     }
     

--- a/ios/Classes/SwiftOcarinaPlugin.swift
+++ b/ios/Classes/SwiftOcarinaPlugin.swift
@@ -88,9 +88,73 @@ class SinglePlayer: Player {
     }
 }
 
+class PlayerDelegate {
+    let loadDelegate: LoadDelegate
+    let playDelegate: PlayDelegate
+    let pauseDelegate: PauseDelegate
+    let resumeDelegate: ResumeDelegate
+    let stopDelegate: StopDelegate
+    let volumeDelegate: VolumeDelegate
+    
+    func load(_ id: Int, assetUrl: String, volume: Double, loop: Bool) {
+        let url: URL = URL(fileURLWithPath: assetUrl)
+        let fileForPlayback: AVAudioFile?
+        do {
+            fileForPlayback = try AVAudioFile(forReading: url)
+        } catch let error {
+            NSLog("Cannot play music. Error opening file \(url) for reading \(error).")
+            return
+        }
+        
+        guard let file = fileForPlayback else {
+            NSLog("Cannot play music. Cannot open file for reading \(url).")
+            return
+        }
+
+        loadDelegate(id, file, loop, volume)
+    }
+    
+    func play(_ id: Int) {
+        playDelegate(id)
+    }
+
+    func pause(_ id: Int) {
+        pauseDelegate(id)
+    }
+
+    func resume(_ id: Int) {
+        resumeDelegate(id)
+    }
+
+    func stop(_ id: Int) {
+        stopDelegate(id)
+    }
+
+    func volume(_ id: Int, volume: Double) {
+        volumeDelegate(id, volume)
+    }
+    
+    init(load: @escaping LoadDelegate, play: @escaping PlayDelegate, pause: @escaping PauseDelegate, resume: @escaping ResumeDelegate, stop: @escaping StopDelegate, volume: @escaping VolumeDelegate) {
+        loadDelegate = load
+        playDelegate = play
+        pauseDelegate = pause
+        resumeDelegate = resume
+        stopDelegate = stop
+        volumeDelegate = volume
+    }
+}
+
+public typealias LoadDelegate = (_ id: Int, _ file: AVAudioFile, _ loop: Bool, _ volume: Double) -> Void
+public typealias PlayDelegate = (_ id: Int) -> Void
+public typealias PauseDelegate = (_ id: Int) -> Void
+public typealias ResumeDelegate = (_ id: Int) -> Void
+public typealias StopDelegate = (_ id: Int) -> Void
+public typealias VolumeDelegate = (_ id: Int, _ volume: Double) -> Void
+
 public class SwiftOcarinaPlugin: NSObject, FlutterPlugin {
     static var players = [Int: Player]()
     static var id: Int = 0;
+    static var delegate: PlayerDelegate?
     var registrar: FlutterPluginRegistrar? = nil
     
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -99,131 +163,196 @@ public class SwiftOcarinaPlugin: NSObject, FlutterPlugin {
         registrar.addMethodCallDelegate(instance, channel: channel)
         instance.registrar = registrar
     }
+
+    public static func useDelegate(load: @escaping LoadDelegate, play: @escaping PlayDelegate, pause: @escaping PauseDelegate, resume: @escaping ResumeDelegate, stop: @escaping StopDelegate, volume: @escaping VolumeDelegate) {
+        delegate = PlayerDelegate(load: load, play: play, pause: pause, resume: resume, stop: stop, volume: volume)
+    }
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         if (call.method == "load") {
-            guard let args = call.arguments else {
-                return;
-            }
-            
-            if let myArgs = args as? [String: Any],
-                let url: String = myArgs["url"] as? String,
-                let volume: Double = myArgs["volume"] as? Double,
-                let isAsset: Bool = myArgs["isAsset"] as? Bool,
-                let loop: Bool = myArgs["loop"] as? Bool {
-                
-                var assetUrl: String
-                if (isAsset) {
-                    let key: String?
-                    if let package: String = myArgs["package"] as? String {
-                     key = registrar?.lookupKey(forAsset: url, fromPackage: package)
-                    } else {
-                     key = registrar?.lookupKey(forAsset: url)
-                    }
-
-                    if let url = Bundle.main.path(forResource: key, ofType: nil) {
-                        assetUrl = url
-                    } else {
-                        return result(FlutterError(code: "ASSET_URL_NOT_FOUND", message: "key: " + (key ?? ""), details: nil))
-                    }
-                } else {
-                    assetUrl = url
-                }
-                
-                let id = SwiftOcarinaPlugin.id
-                if (loop) {
-                    SwiftOcarinaPlugin.players[id] = LoopPlayer(url: assetUrl, volume: volume)
-                } else {
-                    SwiftOcarinaPlugin.players[id] = SinglePlayer(url: assetUrl, volume: volume)
-                }
-                
-                SwiftOcarinaPlugin.id = SwiftOcarinaPlugin.id + 1
-                
-                result(id)
-            }
+            load(call, result: result)
         } else if (call.method == "play") {
-            guard let args = call.arguments else {
-                return;
+            play(call, result: result)
+        } else if (call.method == "pause") {
+            pause(call, result: result)
+        } else if (call.method == "stop") {
+            stop(call, result: result)
+        } else if (call.method == "volume") {
+            volume(call, result: result)
+        } else if (call.method == "resume") {
+            resume(call, result: result)
+        } else if (call.method == "seek") {
+            seek(call, result: result)
+        } else if (call.method == "dispose") {
+            dispose(call, result: result)
+        }
+    }
+    
+    func load(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments else {
+            return;
+        }
+        
+        if let myArgs = args as? [String: Any],
+            let url: String = myArgs["url"] as? String,
+            let volume: Double = myArgs["volume"] as? Double,
+            let isAsset: Bool = myArgs["isAsset"] as? Bool,
+            let loop: Bool = myArgs["loop"] as? Bool {
+            
+            var assetUrl: String
+            if (isAsset) {
+                let key: String?
+                if let package: String = myArgs["package"] as? String {
+                 key = registrar?.lookupKey(forAsset: url, fromPackage: package)
+                } else {
+                 key = registrar?.lookupKey(forAsset: url)
+                }
+
+                if let url = Bundle.main.path(forResource: key, ofType: nil) {
+                    assetUrl = url
+                } else {
+                    return result(FlutterError(code: "ASSET_URL_NOT_FOUND", message: "key: " + (key ?? ""), details: nil))
+                }
+            } else {
+                assetUrl = url
             }
             
-            if let myArgs = args as? [String: Any],
-                let playerId: Int = myArgs["playerId"] as? Int {
-                
+            let id = SwiftOcarinaPlugin.id
+            if let delegate = SwiftOcarinaPlugin.delegate {
+                delegate.load(id, assetUrl: assetUrl, volume: volume, loop: loop)
+            } else if (loop) {
+                SwiftOcarinaPlugin.players[id] = LoopPlayer(url: assetUrl, volume: volume)
+            } else {
+                SwiftOcarinaPlugin.players[id] = SinglePlayer(url: assetUrl, volume: volume)
+            }
+            
+            SwiftOcarinaPlugin.id = SwiftOcarinaPlugin.id + 1
+            
+            result(id)
+        }
+    }
+    
+    func play(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments else {
+            return;
+        }
+        
+        if let myArgs = args as? [String: Any],
+            let playerId: Int = myArgs["playerId"] as? Int {
+            
+            if let delegate = SwiftOcarinaPlugin.delegate {
+                delegate.play(playerId)
+            } else {
                 let player = SwiftOcarinaPlugin.players[playerId]
                 player?.play()
-                result(0)
             }
-        } else if (call.method == "pause") {
-                   guard let args = call.arguments else {
-                       return;
-                   }
-                   
-                   if let myArgs = args as? [String: Any],
-                       let playerId: Int = myArgs["playerId"] as? Int {
-                       
-                       let player = SwiftOcarinaPlugin.players[playerId]
-                       player?.pause()
-                       result(0)
-                   }
-        } else if (call.method == "stop") {
-            guard let args = call.arguments else {
-                return;
+            result(0)
+        }
+    }
+    
+    func pause(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments else {
+            return;
+        }
+        
+        if let myArgs = args as? [String: Any],
+            let playerId: Int = myArgs["playerId"] as? Int {
+         
+            if let delegate = SwiftOcarinaPlugin.delegate {
+                delegate.pause(playerId)
+            } else {
+                let player = SwiftOcarinaPlugin.players[playerId]
+                player?.pause()
             }
-            
-            if let myArgs = args as? [String: Any],
-                let playerId: Int = myArgs["playerId"] as? Int {
-                
+            result(0)
+        }
+    }
+    
+    func stop(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments else {
+            return;
+        }
+        
+        if let myArgs = args as? [String: Any],
+            let playerId: Int = myArgs["playerId"] as? Int {
+
+            if let delegate = SwiftOcarinaPlugin.delegate {
+                delegate.stop(playerId)
+            } else {
                 let player = SwiftOcarinaPlugin.players[playerId]
                 player?.stop()
-                result(0)
             }
+            result(0)
+        }
+    }
+    
+    func volume(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments else {
+            return;
+        }
+        
+        if let myArgs = args as? [String: Any],
+            let playerId: Int = myArgs["playerId"] as? Int,
+            let volume: Double = myArgs["volume"] as? Double {
             
-        } else if (call.method == "volume") {
-            guard let args = call.arguments else {
-                return;
-            }
-            
-            if let myArgs = args as? [String: Any],
-                let playerId: Int = myArgs["playerId"] as? Int,
-                let volume: Double = myArgs["volume"] as? Double {
-                
+            if let delegate = SwiftOcarinaPlugin.delegate {
+                delegate.volume(playerId, volume: volume)
+            } else {
                 let player = SwiftOcarinaPlugin.players[playerId]
                 player?.volume(volume: volume)
-                result(0)
             }
-        } else if (call.method == "resume") {
-            guard let args = call.arguments else {
-                return;
-            }
+            result(0)
+        }
+    }
+    
+    func resume(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments else {
+            return;
+        }
+        
+        if let myArgs = args as? [String: Any],
+            let playerId: Int = myArgs["playerId"] as? Int {
             
-            if let myArgs = args as? [String: Any],
-                let playerId: Int = myArgs["playerId"] as? Int {
-                
+            if let delegate = SwiftOcarinaPlugin.delegate {
+                delegate.resume(playerId)
+            } else {
                 let player = SwiftOcarinaPlugin.players[playerId]
                 player?.resume()
-                result(0)
             }
-        } else if (call.method == "seek") {
-            guard let args = call.arguments else {
-                return;
-            }
+            result(0)
+        }
+    }
+    
+    func seek(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments else {
+            return;
+        }
+        
+        if let myArgs = args as? [String: Any],
+            let playerId: Int = myArgs["playerId"] as? Int,
+            let positionInMillis: Int = myArgs["position"] as? Int {
             
-            if let myArgs = args as? [String: Any],
-                let playerId: Int = myArgs["playerId"] as? Int,
-                let positionInMillis: Int = myArgs["position"] as? Int {
-                
+            if let delegate = SwiftOcarinaPlugin.delegate {
+                result(FlutterMethodNotImplemented)
+            } else {
                 let player = SwiftOcarinaPlugin.players[playerId]
                 player?.seek(position: positionInMillis)
                 result(0)
             }
-        } else if (call.method == "dispose") {
-            guard let args = call.arguments else {
-                return;
-            }
+        }
+    }
+    
+    func dispose(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments else {
+            return;
+        }
+        
+        if let myArgs = args as? [String: Any],
+            let playerId: Int = myArgs["playerId"] as? Int {
             
-            if let myArgs = args as? [String: Any],
-                let playerId: Int = myArgs["playerId"] as? Int {
-                
+            if let delegate = SwiftOcarinaPlugin.delegate {
+                result(FlutterMethodNotImplemented)
+            } else {
                 let player = SwiftOcarinaPlugin.players[playerId]
                 player?.stop()
                 SwiftOcarinaPlugin.players[playerId] = nil

--- a/ios/Classes/SwiftOcarinaPlugin.swift
+++ b/ios/Classes/SwiftOcarinaPlugin.swift
@@ -172,7 +172,7 @@ class PlayerDelegate {
         seekDelegate(id, positionInMillis)
     }
     
-    func position(_ id: Int) -> Int64? {
+    func position(_ id: Int) -> Int64 {
         return positionDelegate(id)
     }
     
@@ -197,7 +197,7 @@ public typealias ResumeDelegate = (_ id: Int) -> Void
 public typealias StopDelegate = (_ id: Int) -> Void
 public typealias VolumeDelegate = (_ id: Int, _ volume: Double) -> Void
 public typealias SeekDelegate = (_ id: Int, _ positionInMillis: Int) -> Void
-public typealias PositionDelegate = (_ id: Int) -> Int64?
+public typealias PositionDelegate = (_ id: Int) -> Int64
 
 public class SwiftOcarinaPlugin: NSObject, FlutterPlugin {
     static var players = [Int: Player]()

--- a/lib/ocarina.dart
+++ b/lib/ocarina.dart
@@ -68,6 +68,11 @@ class OcarinaPlayer {
         'seek', {'playerId': _id, 'position': duration.inMilliseconds});
   }
 
+  Future<int> position() async {
+    _ensureLoaded();
+    return await _channel.invokeMethod('position', {'playerId': _id});
+  }
+
   Future<void> updateVolume(double volume) async {
     _ensureLoaded();
     await _channel.invokeMethod('volume', {'playerId': _id, 'volume': volume});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ocarina
 description: Play local (assets or external/internal storage) audio files with flutter on Android or iOS
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/erickzanardo/ocarina
 
 environment:


### PR DESCRIPTION
This PR is made to allow for delegating audio file playback handling to an external audio engine on iOS. It is developed with the intention of being compatible with the `AVAudioEngineDevice` introduced to [`twilio_programmable_video`](https://pub.dev/packages/twilio_programmable_video) in [this merge request](https://gitlab.com/twilio-flutter/programmable-video/-/merge_requests/83)

This delegation may be enabled by adding the following few lines to the `AppDelegate`s application didFinishLaunchingWithOptions override between plugin registration and return:

```
    
    let audioDevice = AVAudioEngineDevice()
    SwiftTwilioProgrammableVideoPlugin.audioDevice = audioDevice
    SwiftOcarinaPlugin.useDelegate(
        load: audioDevice.addMusicNode,
        dispose: audioDevice.disposeMusicNode,
        play: audioDevice.playMusic,
        pause: audioDevice.pauseMusic,
        resume: audioDevice.resumeMusic,
        stop: audioDevice.stopMusic,
        volume: audioDevice.setMusicVolume,
        seek: audioDevice.seekPosition,
        position: audioDevice.getPosition)
```